### PR TITLE
Fix broken Packaging Release Workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,7 +33,7 @@ jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-latest
-    needs: check_packaging
+    needs: tests
     steps:
     - uses: actions/checkout@master
     - name: Set up Python


### PR DESCRIPTION
Fixes ([log](https://github.com/Hochfrequenz/mig_ahb_utility_stack/actions/runs/1586608846)):
> Invalid workflow file : .github/workflows/python-publish.yml#L36
The workflow is not valid. .github/workflows/python-publish.yml (Line: 36, Col: 12): Job 'build-n-publish' depends on unknown job 'check_packaging'.

![grafik](https://user-images.githubusercontent.com/23094997/146339269-634b6de0-4aba-4274-ba69-507cffb9734b.png)
