### PR TITLE
Allow for yet another weird referencing syntax

### DIFF
--- a/src/maus/reader/etree_element_helpers.py
+++ b/src/maus/reader/etree_element_helpers.py
@@ -23,8 +23,10 @@ def get_segment_group_key_or_none(element: Element) -> Optional[str]:
     return None
 
 
-#: a regex to match a ref-segment: https://regex101.com/r/KY25AH/1
-_nested_qualifier_pattern = re.compile(r"^(?P<segment_code>[A-Z]+):\d+:\d+\[(?:\w+:)+\w+:?=(?P<qualifier>[A-Z\d]+)\]$")
+#: a regex to match a ref-segment: https://regex101.com/r/D81bbO/1
+_nested_qualifier_pattern = re.compile(
+    r"^(?P<segment_code>[A-Z]+):\d+:(?:\d+|\(\d+,\d+\))\[(?:\w+:)+\w+:?=(?P<qualifier>[A-Z\d]+)\]$"
+)
 
 
 def get_nested_qualifier(attrib_key: Literal["ref", "key"], element: Element) -> Optional[str]:

--- a/unit_tests/test_etree_element_helpers.py
+++ b/unit_tests/test_etree_element_helpers.py
@@ -70,6 +70,7 @@ class TestEtreeSingleElementHelpers:
             pytest.param("ref", '<baz ref="DTM:1:1[1:0=469]"></baz>', "469"),
             pytest.param("key", '<baz asd="hello"></baz>', None),
             pytest.param("key", '<foo key="NAD:2:0[1:0=MS]"></foo>', "MS"),
+            pytest.param("ref", '<field ref="FTX:4:(0,4)[1:0=ACB]" />', "ACB"),
         ],
     )
     def test_get_nested_qualifier(self, ref_or_key: Literal["ref", "key"], xml_string: str, expected: Optional[str]):


### PR DESCRIPTION
See

https://github.com/Hochfrequenz/edifact-templates/blob/d9012b14380bf293673446cee5d72b14fc0d5403/edi/UTILMD/UTILMD5.2c.template#L86
