### PR TITLE
🚚 Rename EdifactFormatVersion `FV2204` to `FV2210`

### DIFF
--- a/src/maus/edifact.py
+++ b/src/maus/edifact.py
@@ -61,7 +61,7 @@ class EdifactFormatVersion(str, Enum):
 
     FV2104 = "FV2104"  #: valid from 2021-04-01 until 2021-10-01
     FV2110 = "FV2110"  #: valid from 2021-10-01 until 2022-04-01
-    FV2204 = "FV2204"  #: valid from 2022-04-01 onwards ("MaKo 2022")
+    FV2210 = "FV2210"  #: valid from 2022-10-01 onwards ("MaKo 2022", was 2204 previously)
 
     def __str__(self):
         return self.value


### PR DESCRIPTION
Fixes #85

might be kinda breaking if someone downstream uses FV2204