### PR TITLE
Fix MaKo2022 naming confusions by introducing hardcoded names

### DIFF
--- a/src/maus/models/anwendungshandbuch.py
+++ b/src/maus/models/anwendungshandbuch.py
@@ -296,7 +296,9 @@ class DeepAnwendungshandbuch:
         return result
 
     def find_segments(
-        self, group_predicate: Callable[[SegmentGroup], bool], segment_predicate: Callable[[Segment], bool]
+        self,
+        group_predicate: Callable[[SegmentGroup], bool] = lambda _: True,
+        segment_predicate: Callable[[Segment], bool] = lambda _: True,
     ) -> List[Segment]:
         """
         recursively search for segment characterised by the segment_predicate inside a group characterised by the

--- a/src/maus/reader/flat_ahb_reader.py
+++ b/src/maus/reader/flat_ahb_reader.py
@@ -260,6 +260,8 @@ def _replace_hardcoded_section_names(section_name: Optional[str]) -> Optional[st
         # pylint: disable=line-too-long
         "OBIS-Kennzahl der Zähleinrichtung / Mengenumwerter / Smartmeter-Gateway": "OBIS-Kennzahl der Zähleinrichtung / Mengenumwerter",
         "OBIS-Daten der Zähleinrichtung / Mengenumwerter / Smartmeter-Gateway": "OBIS-Daten der Zähleinrichtung / Mengenumwerter",
+        # https://github.com/Hochfrequenz/edifact-templates/issues/80
+        "OBIS Daten für Lieferant relevant": "OBIS Daten für Marktrolle relevant",
     }
     if section_name.strip() in replacements:
         return replacements[section_name]

--- a/tests/integration_tests/test_anmeldung_maus.py
+++ b/tests/integration_tests/test_anmeldung_maus.py
@@ -47,6 +47,11 @@ class TestAnmeldungMaus:
                 "OBIS-Daten der Zähleinrichtung / Mengenumwerter",
                 "OBIS-Daten der Zähleinrichtung / Mengenumwerter / Smartmeter-Gateway",
             ),
+            (
+                # https://github.com/Hochfrequenz/edifact-templates/issues/80
+                "OBIS Daten für Marktrolle relevant",
+                "OBIS Daten für Lieferant relevant",
+            ),
         ]:
             expected_zaehleinrichtungs_obis = result.maus.find_segments(
                 segment_predicate=lambda seg: seg.section_name == expected_section_name

--- a/tests/integration_tests/test_anmeldung_maus.py
+++ b/tests/integration_tests/test_anmeldung_maus.py
@@ -52,6 +52,11 @@ class TestAnmeldungMaus:
                 "OBIS Daten für Marktrolle relevant",
                 "OBIS Daten für Lieferant relevant",
             ),
+            (
+                # https://github.com/Hochfrequenz/edifact-templates/issues/73
+                "Netznutzungsabrechnungsvariante",
+                "Netznutzungsabrechnungsv ariante",
+            ),
         ]:
             expected_zaehleinrichtungs_obis = result.maus.find_segments(
                 segment_predicate=lambda seg: seg.section_name == expected_section_name

--- a/tests/integration_tests/test_anmeldung_maus.py
+++ b/tests/integration_tests/test_anmeldung_maus.py
@@ -36,6 +36,24 @@ class TestAnmeldungMaus:
             and seg.section_name == "Netznutzungsabrechnungsvariante",
         )
         assert len(nav_segments) == 1  # https://github.com/Hochfrequenz/edifact-templates/issues/73
+        for expected_section_name, unexpected_section_name in [
+            (
+                "OBIS-Kennzahl der Zähleinrichtung / Mengenumwerter",
+                "OBIS-Kennzahl der Zähleinrichtung / Mengenumwerter / Smartmeter-Gateway",
+            ),
+            (
+                "OBIS-Daten der Zähleinrichtung / Mengenumwerter",
+                "OBIS-Daten der Zähleinrichtung / Mengenumwerter / Smartmeter-Gateway",
+            ),
+        ]:
+            expected_zaehleinrichtungs_obis = result.maus.find_segments(
+                segment_predicate=lambda seg: seg.section_name == expected_section_name
+            )
+            assert len(expected_zaehleinrichtungs_obis) > 0
+            unexpected_zaehleinrichtungs_obis = result.maus.find_segments(
+                segment_predicate=lambda seg: seg.section_name == unexpected_section_name
+            )
+            assert len(unexpected_zaehleinrichtungs_obis) == 0
 
     @pytest.mark.datafiles("./edifact-templates/edi/UTILMD/UTILMD5.2c.template")
     @pytest.mark.datafiles("./edifact-templates/ahbs/FV2110/UTILMD/11003.csv")

--- a/tests/integration_tests/test_anmeldung_maus.py
+++ b/tests/integration_tests/test_anmeldung_maus.py
@@ -38,10 +38,12 @@ class TestAnmeldungMaus:
         assert len(nav_segments) == 1  # https://github.com/Hochfrequenz/edifact-templates/issues/73
         for expected_section_name, unexpected_section_name in [
             (
+                # https://github.com/Hochfrequenz/edifact-templates/issues/82
                 "OBIS-Kennzahl der Zähleinrichtung / Mengenumwerter",
                 "OBIS-Kennzahl der Zähleinrichtung / Mengenumwerter / Smartmeter-Gateway",
             ),
             (
+                # https://github.com/Hochfrequenz/edifact-templates/issues/82
                 "OBIS-Daten der Zähleinrichtung / Mengenumwerter",
                 "OBIS-Daten der Zähleinrichtung / Mengenumwerter / Smartmeter-Gateway",
             ),
@@ -54,6 +56,24 @@ class TestAnmeldungMaus:
                 segment_predicate=lambda seg: seg.section_name == unexpected_section_name
             )
             assert len(unexpected_zaehleinrichtungs_obis) == 0
+        assert (
+            len(
+                result.maus.find_segments(
+                    segment_predicate=lambda seg: seg.discriminator == "SEQ"
+                    and seg.section_name == "OBIS-Daten der Marktlokation",
+                )
+            )
+            > 0
+        )  # https://github.com/Hochfrequenz/edifact-templates/issues/81
+        assert (
+            len(
+                result.maus.find_segments(
+                    segment_predicate=lambda seg: seg.discriminator == "CAV"
+                    and seg.section_name == "Druckebene der Marktlokation",
+                )
+            )
+            > 0
+        )  # https://github.com/Hochfrequenz/edifact-templates/issues/79
 
     @pytest.mark.datafiles("./edifact-templates/edi/UTILMD/UTILMD5.2c.template")
     @pytest.mark.datafiles("./edifact-templates/ahbs/FV2110/UTILMD/11003.csv")

--- a/tests/integration_tests/test_eog_maus.py
+++ b/tests/integration_tests/test_eog_maus.py
@@ -13,12 +13,21 @@ class TestEogMaus:
     @pytest.mark.datafiles("./edifact-templates/ahbs/FV2110/UTILMD/11013.csv")
     @pytest.mark.datafiles("../unit_tests/migs/FV2204/segment_group_hierarchies/sgh_utilmd.json")
     def test_maus_creation_11013(self, datafiles):
-        create_maus_and_assert(
+        result = create_maus_and_assert(
             csv_path=Path(datafiles) / "11013.csv",
             sgh_path=Path(datafiles) / "sgh_utilmd.json",
             template_path=Path(datafiles) / Path("UTILMD5.2c.template"),
             maus_path=Path("edifact-templates/maus/FV2110/UTILMD/11013_maus.json"),
         )
+        assert (
+            len(
+                result.maus.find_segments(
+                    segment_predicate=lambda seg: seg.discriminator == "SEQ"
+                    and seg.section_name == "OBIS-Daten der Marktlokation",
+                )
+            )
+            > 0
+        )  # https://github.com/Hochfrequenz/edifact-templates/issues/81
 
     @pytest.mark.datafiles("./edifact-templates/edi/UTILMD/UTILMD5.2c.template")
     @pytest.mark.datafiles("./edifact-templates/ahbs/FV2110/UTILMD/11014.csv")


### PR DESCRIPTION
Asserts fixes of:
- https://github.com/Hochfrequenz/edifact-templates/issues/82
- https://github.com/Hochfrequenz/edifact-templates/issues/81
- https://github.com/Hochfrequenz/edifact-templates/issues/80
- https://github.com/Hochfrequenz/edifact-templates/issues/79 / https://github.com/Hochfrequenz/edifact-templates/issues/72
- https://github.com/Hochfrequenz/edifact-templates/issues/73