### PR TITLE
Fix Pylint: `no-self-use` is no longer a pylint message

### DIFF
--- a/src/maus/models/anwendungshandbuch.py
+++ b/src/maus/models/anwendungshandbuch.py
@@ -115,7 +115,7 @@ class AhbLineSchema(Schema):
     ahb_expression = fields.String(required=False, load_default=None)
     section_name = fields.String(required=False, load_default=None)
 
-    # pylint:disable=unused-argument,no-self-use
+    # pylint:disable=unused-argument
     @post_load
     def deserialize(self, data, **kwargs) -> AhbLine:
         """
@@ -141,7 +141,7 @@ class AhbMetaInformationSchema(Schema):
 
     pruefidentifikator = fields.String(required=True)
 
-    # pylint:disable=unused-argument,no-self-use
+    # pylint:disable=unused-argument
     @post_load
     def deserialize(self, data, **kwargs) -> AhbMetaInformation:
         """
@@ -241,7 +241,7 @@ class FlatAnwendungshandbuchSchema(Schema):
     meta = fields.Nested(AhbMetaInformationSchema)
     lines = fields.List(fields.Nested(AhbLineSchema))
 
-    # pylint:disable=unused-argument,no-self-use
+    # pylint:disable=unused-argument
     @post_load
     def deserialize(self, data, **kwargs) -> FlatAnwendungshandbuch:
         """
@@ -319,7 +319,7 @@ class DeepAnwendungshandbuchSchema(Schema):
     meta = fields.Nested(AhbMetaInformationSchema)
     lines = fields.List(fields.Nested(SegmentGroupSchema))
 
-    # pylint:disable=unused-argument,no-self-use
+    # pylint:disable=unused-argument
     @post_load
     def deserialize(self, data, **kwargs) -> DeepAnwendungshandbuch:
         """

--- a/src/maus/models/edifact_components.py
+++ b/src/maus/models/edifact_components.py
@@ -89,7 +89,7 @@ class DataElementFreeTextSchema(DataElementSchema):
     ahb_expression = fields.String(required=True)
     entered_input = fields.String(required=False, load_default=None)
 
-    # pylint:disable=unused-argument,no-self-use
+    # pylint:disable=unused-argument
     @post_load
     def deserialize(self, data, **kwargs) -> DataElementFreeText:
         """
@@ -162,7 +162,7 @@ class ValuePoolEntrySchema(Schema):
     meaning = fields.String(required=True)
     ahb_expression = fields.String(required=True)
 
-    # pylint:disable=unused-argument,no-self-use
+    # pylint:disable=unused-argument
     @post_load
     def deserialize(self, data, **kwargs) -> ValuePoolEntry:
         """
@@ -202,7 +202,7 @@ class DataElementValuePoolSchema(DataElementSchema):
 
     value_pool = fields.List(fields.Nested(ValuePoolEntrySchema), required=True)
 
-    # pylint:disable=unused-argument,no-self-use
+    # pylint:disable=unused-argument
     @post_load
     def deserialize(self, data, **kwargs) -> DataElementValuePool:
         """
@@ -242,7 +242,7 @@ class _FreeTextOrValuePoolSchema(Schema):
     value_pool = fields.Nested("DataElementValuePoolSchema", required=False, allow_none=True)
     # see https://github.com/fuhrysteve/marshmallow-jsonschema/issues/164
 
-    # pylint:disable= unused-argument, no-self-use
+    # pylint:disable= unused-argument
     @post_load
     def deserialize(self, data, **kwargs) -> Type[DataElement]:
         """
@@ -254,7 +254,7 @@ class _FreeTextOrValuePoolSchema(Schema):
             return data["value_pool"]
         return data
 
-    # pylint:disable= unused-argument, no-self-use
+    # pylint:disable= unused-argument
     @post_dump
     def post_dump_helper(self, data, **kwargs) -> dict:
         """
@@ -266,7 +266,7 @@ class _FreeTextOrValuePoolSchema(Schema):
             return data["free_text"]
         raise NotImplementedError(f"Data {data} is not implemented for JSON serialization")
 
-    # pylint:disable= unused-argument, no-self-use
+    # pylint:disable= unused-argument
     @pre_load
     def pre_load_helper(self, data, **kwargs) -> dict:
         """
@@ -284,7 +284,7 @@ class _FreeTextOrValuePoolSchema(Schema):
             }
         raise NotImplementedError(f"Data {data} is not implemented for JSON deserialization")
 
-    # pylint:disable= unused-argument, no-self-use
+    # pylint:disable= unused-argument
     @pre_dump
     def prepare_for_serialization(self, data, **kwargs) -> _FreeTextOrValuePool:
         """
@@ -341,7 +341,7 @@ class SegmentSchema(SegmentLevelSchema):
     data_elements = fields.List(fields.Nested(_FreeTextOrValuePoolSchema))
     section_name = fields.String(required=False)
 
-    # pylint:disable=unused-argument,no-self-use
+    # pylint:disable=unused-argument
     @post_load
     def deserialize(self, data, **kwargs) -> Segment:
         """
@@ -401,7 +401,7 @@ class SegmentGroupSchema(SegmentLevelSchema):
         required=False,
     )
 
-    # pylint:disable=unused-argument,no-self-use
+    # pylint:disable=unused-argument
     @post_load
     def deserialize(self, data, **kwargs) -> SegmentGroup:
         """

--- a/src/maus/models/message_implementation_guide.py
+++ b/src/maus/models/message_implementation_guide.py
@@ -72,7 +72,7 @@ class SegmentGroupHierarchySchema(Schema):
         fields.Nested(lambda: SegmentGroupHierarchySchema()), allow_none=True  # pylint:disable=unnecessary-lambda
     )
 
-    # pylint:disable=unused-argument,no-self-use
+    # pylint:disable=unused-argument
     @post_load
     def deserialize(self, data, **kwargs) -> SegmentGroupHierarchy:
         """

--- a/src/maus/reader/mig_reader.py
+++ b/src/maus/reader/mig_reader.py
@@ -159,7 +159,6 @@ class MigXmlReader(MigReader):
         ]
         return list_to_mig_filter_result(filtered)
 
-    # pylint:disable=no-self-use
     def get_unique_result_by_predecessor(self, candidates: List[Element], query: EdifactStackQuery) -> MigFilterResult:
         """
         Keep those elements that have (in the field) the given predecessor qualifier


### PR DESCRIPTION
see release notes: https://github.com/PyCQA/pylint/blob/214201a07aef7068013ff3af1c3cbd479ac39146/doc/whatsnew/2/2.14/summary.rst

> We removed no-init and made no-self-use optional as they were too opinionated.

Fixes: 
> E0012: Bad option value for disable. Don't recognize message no-self-use. (bad-option-value)