### PR TITLE
Move `entered_input` to (abstract) `DataElement`

### DIFF
--- a/src/maus/__init__.py
+++ b/src/maus/__init__.py
@@ -34,6 +34,7 @@ def merge_lines_with_same_data_element(ahb_lines: Sequence[AhbLine]) -> DataElem
             discriminator=ahb_lines[0].get_discriminator(include_name=False),
             value_pool=[],
             data_element_id=ahb_lines[0].data_element,  # type:ignore[arg-type]
+            entered_input=None,
         )
         for data_element_value_entry in ahb_lines:
             if data_element_value_entry.name is None:

--- a/src/maus/deep_ahb_mig_joiner.py
+++ b/src/maus/deep_ahb_mig_joiner.py
@@ -96,6 +96,7 @@ def _data_element_has_a_known_problem(data_element: DataElement):
             ValuePoolEntry(qualifier="Z11", meaning="Gerätenummer des Mengenumwerters", ahb_expression="X"),
             ValuePoolEntry(qualifier="Z14", meaning="Smartmeter-Gateway", ahb_expression="X"),
         ],
+        entered_input=None,
     ):
         # https://github.com/Hochfrequenz/edifact-templates/issues/65
         return True
@@ -108,6 +109,7 @@ def _data_element_has_a_known_problem(data_element: DataElement):
                 qualifier="Z06", meaning="gegenüber Lieferant bestätigtes Kündigungsdatum", ahb_expression="X"
             ),
         ],
+        entered_input=None,
     ):
         # https://github.com/Hochfrequenz/edifact-templates/issues/69
         return True

--- a/src/maus/models/edifact_components.py
+++ b/src/maus/models/edifact_components.py
@@ -49,9 +49,18 @@ class DataElement(ABC):
     #: the ID of the data element (e.g. "0062") for the Nachrichten-Referenznummer
     data_element_id: str = attrs.field(validator=attrs.validators.matches_re(r"^\d{4}$"))
     #: the type of data expected to be used with this data element
+    entered_input: Optional[str] = attrs.field(validator=attrs.validators.optional(attrs.validators.instance_of(str)))
+    """
+    If the message which is evaluated contains data for this data element, this is set to a value which is not None.
+    The field can either carry a free text or an element from a value pool (depending on the value_type)
+    """
     value_type: Optional[DataElementDataType] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(DataElementDataType)), default=None
     )
+    """
+    The value_type allows to describe which type of data we're expecting to be used within this data element.
+    The value_type does not discriminate the type of the data element itself.
+    """
 
 
 class DataElementSchema(Schema):
@@ -61,6 +70,7 @@ class DataElementSchema(Schema):
 
     discriminator = fields.String(required=True)
     data_element_id = fields.String(required=True)
+    entered_input = fields.String(required=False, load_default=None)
     value_type = EnumField(DataElementDataType, required=False)
 
 
@@ -77,8 +87,6 @@ class DataElementFreeText(DataElement):
     )
     ahb_expression: str = attrs.field(validator=attrs.validators.instance_of(str))
     """any freetext data element has an ahb expression attached. Could be 'X' but also 'M [13]'"""
-    entered_input: Optional[str] = attrs.field(validator=attrs.validators.optional(attrs.validators.instance_of(str)))
-    """If the message contains data for this data element, this is not None."""
 
 
 class DataElementFreeTextSchema(DataElementSchema):
@@ -87,7 +95,6 @@ class DataElementFreeTextSchema(DataElementSchema):
     """
 
     ahb_expression = fields.String(required=True)
-    entered_input = fields.String(required=False, load_default=None)
 
     # pylint:disable=unused-argument
     @post_load

--- a/tests/unit_tests/test_ahb.py
+++ b/tests/unit_tests/test_ahb.py
@@ -323,6 +323,7 @@ class TestAhb:
                                             ],
                                             discriminator="baz",
                                             data_element_id="0123",
+                                            entered_input="HELLO",
                                         ),
                                         DataElementFreeText(
                                             ahb_expression="Muss [1]",
@@ -371,6 +372,7 @@ class TestAhb:
                                             "discriminator": "baz",
                                             "data_element_id": "0123",
                                             "value_type": "VALUE_POOL",
+                                            "entered_input": "HELLO",
                                         },
                                         {
                                             "ahb_expression": "Muss [1]",
@@ -427,6 +429,7 @@ class TestAhb:
                                                 ValuePoolEntry(qualifier="MAUS", meaning="rocks", ahb_expression="X"),
                                             ],
                                             discriminator="baz",
+                                            entered_input="HELLO",
                                             data_element_id="0123",
                                         ),
                                         DataElementFreeText(
@@ -459,6 +462,7 @@ class TestAhb:
                                                 ValuePoolEntry(qualifier="MAUS", meaning="rocks", ahb_expression="X"),
                                             ],
                                             discriminator="baz",
+                                            entered_input="MAUS",
                                             data_element_id="0123",
                                         ),
                                         DataElementFreeText(

--- a/tests/unit_tests/test_edifact_components.py
+++ b/tests/unit_tests/test_edifact_components.py
@@ -57,6 +57,7 @@ class TestEdifactComponents:
                     ],
                     discriminator="foo",
                     data_element_id="0022",
+                    entered_input="asd",
                 ),
                 {
                     "value_pool": [
@@ -66,6 +67,7 @@ class TestEdifactComponents:
                     "discriminator": "foo",
                     "data_element_id": "0022",
                     "value_type": "VALUE_POOL",
+                    "entered_input": "asd",
                 },
             ),
         ],
@@ -88,6 +90,7 @@ class TestEdifactComponents:
                             ],
                             discriminator="baz",
                             data_element_id="0329",
+                            entered_input="foo",
                         ),
                         DataElementFreeText(
                             ahb_expression="Muss [1]",
@@ -110,6 +113,7 @@ class TestEdifactComponents:
                             "discriminator": "baz",
                             "data_element_id": "0329",
                             "value_type": "VALUE_POOL",
+                            "entered_input": "foo",
                         },
                         {
                             "ahb_expression": "Muss [1]",
@@ -147,6 +151,7 @@ class TestEdifactComponents:
                                     ],
                                     discriminator="baz",
                                     data_element_id="3333",
+                                    entered_input="MAUS",
                                 ),
                                 DataElementFreeText(
                                     ahb_expression="Muss [1]",
@@ -187,6 +192,7 @@ class TestEdifactComponents:
                                         {"qualifier": "HELLO", "meaning": "world", "ahb_expression": "X"},
                                         {"qualifier": "MAUS", "meaning": "rocks", "ahb_expression": "X"},
                                     ],
+                                    "entered_input": "MAUS",
                                     "discriminator": "baz",
                                     "data_element_id": "3333",
                                     "value_type": "VALUE_POOL",

--- a/tests/unit_tests/test_maus.py
+++ b/tests/unit_tests/test_maus.py
@@ -62,6 +62,7 @@ class TestMaus:
                         ),
                     ],
                     data_element_id="0333",
+                    entered_input=None,
                 ),
             ),
             pytest.param(
@@ -163,6 +164,7 @@ class TestMaus:
                             ahb_expression="X",
                         ),
                     ],
+                    entered_input=None,
                     data_element_id="0333",
                 ),
             ),
@@ -240,6 +242,7 @@ class TestMaus:
                                                 ahb_expression="X",
                                             ),
                                         ],
+                                        entered_input=None,
                                         data_element_id="0333",
                                     )
                                 ],
@@ -294,6 +297,7 @@ class TestMaus:
                                                 ahb_expression="X",
                                             ),
                                         ],
+                                        entered_input=None,
                                         data_element_id="0333",
                                     )
                                 ],
@@ -451,6 +455,7 @@ class TestMaus:
                                                             ahb_expression="X",
                                                         ),
                                                     ],
+                                                    entered_input=None,
                                                     data_element_id="0333",
                                                 )
                                             ],


### PR DESCRIPTION
so that not only "free text" but also "value pool" data elements can hold an `entered_input`. THis is necessary so that we can validate them (in ahbicht and applications using ahbicht)

No idea why didn't do this from the beginning.