### PR TITLE
➕ Add helper method to get current EdifactFormatVersion

### DIFF
--- a/src/maus/edifact.py
+++ b/src/maus/edifact.py
@@ -87,6 +87,14 @@ def get_edifact_format_version(key_date: datetime.datetime) -> EdifactFormatVers
     return EdifactFormatVersion.FV2304
 
 
+def get_current_edifact_format_version() -> EdifactFormatVersion:
+    """
+    returns the edifact_format_version that is valid as of now
+    """
+    tz_aware_now = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+    return get_edifact_format_version(tz_aware_now)
+
+
 def is_edifact_boilerplate(segment_code: Optional[str]) -> bool:
     """
     returns true iff this segment is not relevant in a sense that it has to be validated or merged with the AHB

--- a/tests/unit_tests/test_edifact_enums.py
+++ b/tests/unit_tests/test_edifact_enums.py
@@ -6,6 +6,7 @@ import pytest  # type:ignore[import]
 from maus.edifact import (
     EdifactFormat,
     EdifactFormatVersion,
+    get_current_edifact_format_version,
     get_edifact_format_version,
     is_edifact_boilerplate,
     pruefidentifikator_to_format,
@@ -52,6 +53,10 @@ class TestEdifact:
     def test_format_version_from_keydate(self, key_date: datetime, expected_result: EdifactFormatVersion):
         actual = get_edifact_format_version(key_date)
         assert actual == expected_result
+
+    def test_get_current_format_version(self):
+        actual = get_current_edifact_format_version()
+        assert isinstance(actual, EdifactFormatVersion) is True
 
     @pytest.mark.parametrize(
         "illegal_pruefi",


### PR DESCRIPTION
to avoid that users of maus go through datetime (timezone naive/aware) troubles