### PR TITLE
✨📑 Add `maus_version` to `AhbMetaInformation`

### DIFF
--- a/src/maus/__init__.py
+++ b/src/maus/__init__.py
@@ -17,7 +17,8 @@ from maus.models.edifact_components import (
 )
 from maus.models.message_implementation_guide import SegmentGroupHierarchy
 
-_VERSION = "0.2.3" #: version to be writen into the deep ahb
+_VERSION = "0.2.3"  #: version to be writen into the deep ahb
+
 
 def merge_lines_with_same_data_element(ahb_lines: Sequence[AhbLine]) -> DataElement:
     """

--- a/src/maus/__init__.py
+++ b/src/maus/__init__.py
@@ -17,6 +17,7 @@ from maus.models.edifact_components import (
 )
 from maus.models.message_implementation_guide import SegmentGroupHierarchy
 
+_VERSION = "0.2.3" #: version to be writen into the deep ahb
 
 def merge_lines_with_same_data_element(ahb_lines: Sequence[AhbLine]) -> DataElement:
     """
@@ -151,6 +152,7 @@ def to_deep_ahb(
     Converts a flat ahb into a nested ahb using the provided segment hierarchy
     """
     result = DeepAnwendungshandbuch(meta=flat_ahb.meta, lines=[])
+    result.meta.maus_version = _VERSION
     flat_ahb.sort_lines_by_segment_groups()
     flat_groups = group_lines_by_segment_group(flat_ahb.lines, segment_group_hierarchy)
     # in a first step we group the lines by their segment groups but ignore the actual hierarchy except for the order

--- a/src/maus/models/anwendungshandbuch.py
+++ b/src/maus/models/anwendungshandbuch.py
@@ -150,6 +150,13 @@ class AhbMetaInformation:
 
     pruefidentifikator: str  #: identifies the message type (within a fixed format version) e.g. "11042" or "13012"
     # there's more to come  but for now we'll leave it as is, because we're just in a proof of concept phase
+    maus_version: Optional[str] = attrs.field(
+        validator=attrs.validators.optional(attrs.validators.optional(_check_that_string_is_not_whitespace_or_empty)),
+        default=None,
+    )
+    """
+    semantic version of maus used to create this document
+    """
 
 
 class AhbMetaInformationSchema(Schema):
@@ -158,6 +165,7 @@ class AhbMetaInformationSchema(Schema):
     """
 
     pruefidentifikator = fields.String(required=True)
+    maus_version = fields.String(required=False)
 
     # pylint:disable=unused-argument
     @post_load

--- a/tests/unit_tests/test_ahb.py
+++ b/tests/unit_tests/test_ahb.py
@@ -23,12 +23,8 @@ from maus.models.edifact_components import (
     ValuePoolEntry,
 )
 
-meta_x = AhbMetaInformation(
-    pruefidentifikator="11042",
-)
-meta_y = AhbMetaInformation(
-    pruefidentifikator="11043",
-)
+meta_x = AhbMetaInformation(pruefidentifikator="11042", maus_version="0.2.3")
+meta_y = AhbMetaInformation(pruefidentifikator="11043", maus_version="0.2.3")
 
 line_x = AhbLine(
     ahb_expression="Muss [1] O [2]",
@@ -59,12 +55,8 @@ class TestAhb:
         "ahb, expected_json_dict",
         [
             pytest.param(
-                AhbMetaInformation(
-                    pruefidentifikator="11042",
-                ),
-                {
-                    "pruefidentifikator": "11042",
-                },
+                AhbMetaInformation(pruefidentifikator="11042", maus_version="0.2.3"),
+                {"pruefidentifikator": "11042", "maus_version": "0.2.3"},
             ),
         ],
     )
@@ -246,7 +238,7 @@ class TestAhb:
         [
             pytest.param(
                 FlatAnwendungshandbuch(
-                    meta=AhbMetaInformation(pruefidentifikator="11042"),
+                    meta=AhbMetaInformation(pruefidentifikator="11042", maus_version="0.2.3"),
                     lines=[
                         AhbLine(
                             ahb_expression="Muss [1] O [2]",
@@ -261,7 +253,7 @@ class TestAhb:
                     ],
                 ),
                 {
-                    "meta": {"pruefidentifikator": "11042"},
+                    "meta": {"pruefidentifikator": "11042", "maus_version": "0.2.3"},
                     "lines": [
                         {
                             "ahb_expression": "Muss [1] O [2]",
@@ -331,7 +323,7 @@ class TestAhb:
         [
             pytest.param(
                 DeepAnwendungshandbuch(
-                    meta=AhbMetaInformation(pruefidentifikator="11042"),
+                    meta=AhbMetaInformation(pruefidentifikator="11042", maus_version="0.2.3"),
                     lines=[
                         SegmentGroup(
                             ahb_expression="expr A",
@@ -379,7 +371,7 @@ class TestAhb:
                     ],
                 ),
                 {
-                    "meta": {"pruefidentifikator": "11042"},
+                    "meta": {"pruefidentifikator": "11042", "maus_version": "0.2.3"},
                     "lines": [
                         {
                             "ahb_expression": "expr A",

--- a/tests/unit_tests/test_maus.py
+++ b/tests/unit_tests/test_maus.py
@@ -413,7 +413,7 @@ class TestMaus:
                     ],
                 ),
                 DeepAnwendungshandbuch(
-                    meta=AhbMetaInformation(pruefidentifikator="12345"),
+                    meta=AhbMetaInformation(pruefidentifikator="12345", maus_version="0.2.3"),
                     lines=[
                         SegmentGroup(
                             discriminator="root",

--- a/tests/unit_tests/test_maus_provider.py
+++ b/tests/unit_tests/test_maus_provider.py
@@ -46,7 +46,9 @@ class TestMausProvider:
         maus_root_dir.mkdir("FV2104")
         maus_root_dir.mkdir("FV2104/UTILMD")
         # a minimal maus that is serializable and deserializable
-        example_maus = DeepAnwendungshandbuch(meta=AhbMetaInformation(pruefidentifikator="11001"), lines=[])
+        example_maus = DeepAnwendungshandbuch(
+            meta=AhbMetaInformation(pruefidentifikator="11001", maus_version="0.2.3"), lines=[]
+        )
         with open(maus_root_dir / "FV2104/UTILMD/11001_maus.json", "w+") as maus_test_outfile:
             deep_ahb_dict = DeepAnwendungshandbuchSchema().dump(example_maus)  # create a dictionary
             json.dump(deep_ahb_dict, maus_test_outfile)  # dump the dictionary to the file


### PR DESCRIPTION
this will later allow to distinguish with which version a maus file has been created and allows us to drop support for older format versions