### PR TITLE
Set attrs v22.1.0 as min version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "attrs>=21.4.0",
+    "attrs>=22.1.0",
     "marshmallow>=3.18.0",
     "more_itertools",
     # add everything you add in requirements.in here

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-attrs
+attrs>=22.1.0
 marshmallow
 lxml>=4.9.2
 more_itertools


### PR DESCRIPTION
because the min_len validator has been introduced there.
fixes E   AttributeError: module 'attrs.validators' has no attribute 'min_len'

