### PR TITLE
🐛Fix copy paste (`FV2310` != `FV2304`)

### DIFF
--- a/src/maus/edifact.py
+++ b/src/maus/edifact.py
@@ -73,7 +73,7 @@ class EdifactFormatVersion(str, Enum):
     FV2110 = "FV2110"  #: valid from 2021-10-01 until 2022-04-01
     FV2210 = "FV2210"  #: valid from 2022-10-01 onwards ("MaKo 2022", was 2204 previously)
     FV2304 = "FV2304"  #: valid from 2023-04-01 onwards
-    FV2310 = "FV2304"  #: valid from 2023-10-01 onwards
+    FV2310 = "FV2310"  #: valid from 2023-10-01 onwards
     FV2404 = "FV2404"  #: valid from 2024-04-01 onwards
     # whenever you add another value here, please also make sure to add its key date to get_edifact_format_version below
 


### PR DESCRIPTION
fixes:
> 'FV2310' is not a valid EdifactFormatVersion